### PR TITLE
Added replies parameter

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -32,6 +32,7 @@ Options available with the shortcode:
 * `post_status` - the status of posts to retrieve comments for. Defaults to 'publish'. Can be a single status or a comma-separated list, or 'any' to show comments for all post statuses.
 * `post_type` - the post type to retrieve comments for. Accepts a single post type (e.g. 'post') or 'any' to show comments for all post types. Default: 'any'
 * `excerpts` - set to 'true' to show an excerpt of the comment (limited to 20 words), or 'false' to show the full comment. Default: true
+* `replies` - set to 'true' to also show responses to comments, or 'false' to only see the top level comments. Default: true
 
 == Installation ==
 

--- a/src/Util.php
+++ b/src/Util.php
@@ -20,7 +20,8 @@ class Util {
 			'avatar_size' => 50,
 			'post_status' => 'publish',
 			'post_type'   => 'any',
-			'excerpts'    => true
+			'excerpts'    => true,
+			'replies'     => 'true',
 		];
 	}
 
@@ -53,12 +54,14 @@ class Util {
 		// Sanitize post status used to retrieve comments.
 		$post_status = array_filter( array_map( 'sanitize_key', explode( ',', $args['post_status'] ) ) );
 		$post_type   = sanitize_key( $args['post_type'] );
+		$replies     = sanitize_key( $args['replies'] );
 
 		$comment_args = [
 			'number'      => absint( filter_var( $args['number'], FILTER_VALIDATE_INT ) ),
 			'status'      => 'approve',
 			'post_status' => $post_status,
 			'post_type'   => $post_type,
+			'hierarchical'=> $replies == 'false' ? 'threaded' : false,
 			'type'        => apply_filters( 'better_recent_comments_comment_type', 'comment' )
 		];
 


### PR DESCRIPTION
I use to give a reply to people commenting on my blog posts. I didn't want my own comments to show up in the latest comments view that I show on the frontpage. Therefore I added the possibility to only show top-level comments and not replies. That was an easy way to hide my own comments. Maybe something others can benefit of as well.