### PR TITLE
Remove .git from .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,5 @@
 /.wordpress-org export-ignore
 /.github export-ignore
-/.git export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /gulpfile.js export-ignore


### PR DESCRIPTION
`.git` directory is never exported.


Test it with this command.

```bash
git archive HEAD | tar --list
```
