### PR TITLE
Bump "Tested up to" WP 6.6.1

### DIFF
--- a/better-recent-comments.php
+++ b/better-recent-comments.php
@@ -17,7 +17,7 @@
  * Text Domain:     better-recent-comments
  * Domain Path:     /languages
  * Requires at least: 6.0
- * Tested up to: 6.5
+ * Tested up to: 6.6.1
  * Requires PHP: 7.4
  *
  * Copyright:       Kestrel

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: kestrelwp
 Donate link: https://kestrelwp.com
 Tags: comments, widget, avatar, shortcode, wpml
 Requires at least: 6.0
-Tested up to: 6.4
+Tested up to: 6.6.1
 Requires PHP: 7.4
 Stable tag: 1.2.0
 License: GPL-3.0


### PR DESCRIPTION
### Summary

[SC-3362](https://app.shortcut.com/kestrel/story/3362/better-recent-comments-test-and-declare-compatibility-with-wp6-6-1)

Declaring that we have tested up to WP 6.6.1.